### PR TITLE
Make sure stringprep isn't compiled to native code

### DIFF
--- a/src/stringprep.erl
+++ b/src/stringprep.erl
@@ -28,6 +28,8 @@
 
 -author('alexey@process-one.net').
 
+-compile(no_native).
+
 -export([start/0, load_nif/0, tolower/1, nameprep/1,
 	 nodeprep/1, resourceprep/1]).
 


### PR DESCRIPTION
NIFs [cannot][1] be loaded from a HiPE-compiled module.

[1]: http://erlang.org/pipermail/erlang-questions/2011-June/059237.html