### PR TITLE
Update hex packaged files

### DIFF
--- a/src/stringprep.app.src
+++ b/src/stringprep.app.src
@@ -29,7 +29,7 @@
   {mod,          {stringprep_app,[]}},
 
   %% hex.pm packaging:
-  {files, ["src/", "c_src/stringprep.cpp", "c_src/uni_data.c", "c_src/uni_norm.c", "rebar.config", "rebar.config.script", "README.md", "LICENSE.txt", "LICENCE.ALL", "LICENSE.TCL"]},
+  {files, ["src/", "c_src/stringprep.cpp", "c_src/uni_data.c", "c_src/uni_norm.c", "configure", "rebar.config", "rebar.config.script", "vars.config.in", "README.md", "LICENSE.txt", "LICENCE.ALL", "LICENSE.TCL"]},
   {licenses, ["Apache 2.0", "Tcl/Tk"]},
   {links, [{"Github", "https://github.com/processone/stringprep"}]}]}.
 


### PR DESCRIPTION
'configure' and 'vars.config.in' are required to build as ejabberd
dependencies with rebar3