### PR TITLE
Return ok from load_nif() when NIF is already loaded

### DIFF
--- a/src/stringprep.erl
+++ b/src/stringprep.erl
@@ -43,6 +43,7 @@ load_nif() ->
     SOPath = p1_nif_utils:get_so_path(?MODULE, [stringprep], "stringprep"),
     case catch erlang:load_nif(SOPath, 0) of
         ok -> ok;
+        {error, {reload, _}} -> ok;
         Err -> error_logger:warning_msg("unable to load stringprep NIF: ~p~n", [Err]),
                {error, unable_to_load_nif}
     end.

--- a/test/tests.erl
+++ b/test/tests.erl
@@ -8,6 +8,12 @@ application_start_test_() ->
                     application:ensure_all_started(stringprep)),
       ?_assertEqual(ok, stringprep:start()) ].
 
+application_start_stop_start_test_() ->
+    [ ?_assertEqual({ok, []},
+                    application:ensure_all_started(stringprep)),
+      ?_assertEqual(ok, application:stop(stringprep)),
+      ?_assertEqual(ok, stringprep:start()) ].
+
 badarg_test() ->
     ?assertError(badarg, stringprep:nodeprep(foo)),
     ?assertError(badarg, stringprep:nameprep(123)),


### PR DESCRIPTION
Hello, and thanks for `stringprep`!

I've recently found myself in a situation where I am testing an Erlang application, and some of my test suites depend on the `stringprep` application/NIF being started. In the interest of keeping test suites hermetic and not leaking started applications to subsequent test suites, I've gotten into the habit of stopping any applications I've started for any given test suite.

Calling `application:ensure_all_started(stringprep)` returns `{error, {reload, "NIF library already loaded (reload disallowed since OTP 20)."}}` when the stringprep NIF has already been loaded. The proposed change is to match this return from `erlang:load_nif/2` and instead have `stringprep:load_nif/0` return `ok` when the NIF has already been loaded from a previous call.